### PR TITLE
Fix createTypes file link example

### DIFF
--- a/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.md
+++ b/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.md
@@ -102,7 +102,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
   createTypes(`
     type CustomImage implements Node {
-      localImage: File @link
+      localImage: File @link(from: "localImageId")
     }
   `)
 }


### PR DESCRIPTION
Without `(from: "localImageId")` the `localImage` field will always be empty.